### PR TITLE
✨ Feature: 반응 조회에 작품 정보을 포함

### DIFF
--- a/app/schemas/reaction.py
+++ b/app/schemas/reaction.py
@@ -3,10 +3,9 @@ from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel, Field, validator
 
-if TYPE_CHECKING:
-    from app.schemas.artwork import ArtworkResponse
-    from app.schemas.tag import TagResponse
-    from app.schemas.visitor import VisitorResponse
+from app.schemas.artwork import ArtworkResponse
+from app.schemas.tag import TagResponse
+from app.schemas.visitor import VisitorResponse
 
 
 class ReactionCreate(BaseModel):
@@ -84,6 +83,7 @@ class ReactionResponse(BaseModel):
 
     id: int
     artwork_id: int
+    artwork: ArtworkResponse
     visitor_id: int
     visit_id: Optional[int] = None
     comment: Optional[str] = None

--- a/app/schemas/visit_history.py
+++ b/app/schemas/visit_history.py
@@ -1,12 +1,12 @@
-from datetime import datetime
-from typing import TYPE_CHECKING, List
+from datetime import datetime, date
+from typing import List
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from app.schemas.exhibition import ExhibitionResponse
-    from app.schemas.reaction import ReactionResponse
-    from app.schemas.visitor import VisitorResponse
+from app.schemas.artwork import ArtworkResponse
+from app.schemas.exhibition import ExhibitionResponse
+from app.schemas.reaction import ReactionResponse
+from app.schemas.visitor import VisitorResponse
 
 
 class VisitHistoryCreate(BaseModel):


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #56 

---

### 🧶 주요 변경 내용 (Summary)

#### ReactionResponse 스키마 개선
- `artwork` 필드 추가 (ArtworkResponse)
- 반응 조회 시 작품 정보 자동 포함

#### 효과
- VisitHistoryDetail 조회 시 `reactions[].artwork`로 작품 정보 확인 가능
- iOS에서 "이 방문에서 반응 남긴 작품들" 표시 가능

---

### 🧪 테스트 / 검증 내역

- [x] GET /reactions - artwork 정보 포함 확인
- [x] GET /visit-histories/{id} - reactions 내 artwork 확인
- [x] 기존 API 동작 정상 확인

---

### ⚡️ 응답 예시

```json
{
  "reactions": [
    {
      "id": 1,
      "artwork_id": 3,
      "artwork": {
        "id": 3,
        "title": "작품 제목",
        "thumbnail_url": "https://..."
      }
    }
  ]
}
```