### PR TITLE
🎯 Epic: API Reponse 수정 / 추가

### DIFF
--- a/app/api/v1/endpoints/visit_histories.py
+++ b/app/api/v1/endpoints/visit_histories.py
@@ -1,22 +1,35 @@
 # app/api/v1/endpoints/visit_histories.py
-from typing import List
+from typing import List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
 from app.models.exhibition import Exhibition
+from app.models.reaction import Reaction
 from app.models.visit_history import VisitHistory
 from app.models.visitor import Visitor
-from app.schemas.visit_history import VisitHistoryCreate, VisitHistoryResponse
-from fastapi import APIRouter, Depends, HTTPException, status
+from app.schemas.visit_history import (
+    VisitHistoryCreate,
+    VisitHistoryDetail,
+    VisitHistoryResponse,
+)
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 router = APIRouter(prefix="/visit-histories", tags=["Visit Histories"])
 
 
 @router.post(
-    "", response_model=VisitHistoryResponse, status_code=status.HTTP_201_CREATED
+    "",
+    response_model=VisitHistoryResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="방문 기록 생성",
+    description="새 방문 기록을 생성합니다.",
 )
-def create_visit_history(visit_data: VisitHistoryCreate, db: Session = Depends(get_db)):
+def create_visit_history(
+    visit_data: VisitHistoryCreate,
+    db: Session = Depends(get_db)
+):
     """
     방문 기록 생성
 
@@ -53,7 +66,8 @@ def create_visit_history(visit_data: VisitHistoryCreate, db: Session = Depends(g
     db.commit()
     db.refresh(new_visit)
 
-    return new_visit
+    # 생성 후 상세 정보 조회하여 반환 (Response 형식)
+    return get_visit_history_response(new_visit.id, db)
 
 
 @router.get(
@@ -63,52 +77,164 @@ def create_visit_history(visit_data: VisitHistoryCreate, db: Session = Depends(g
     description="방문 기록 목록을 조회합니다. visitor_id와 exhibition_id로 필터링 가능합니다.",
 )
 def get_visit_histories(
-    visitor_id: int = None, exhibition_id: int = None, db: Session = Depends(get_db)
+    visitor_id: Optional[int] = Query(None, description="관람객 ID로 필터링"),
+    exhibition_id: Optional[int] = Query(None, description="전시 ID로 필터링"),
+    db: Session = Depends(get_db),
 ):
     """
-    방문 기록 조회
+    방문 기록 목록 조회 (가벼운 버전)
 
     Args:
         visitor_id: 관람객 ID로 필터링
         exhibition_id: 전시 ID로 필터링
 
     Returns:
-        List[VisitHistoryResponse]: 방문 기록 목록
+        List[VisitHistoryResponse]: 방문 기록 목록 (visitor_name, exhibition_title, reaction_count 포함)
     """
-    query = db.query(VisitHistory)
+    # 쿼리 구성 (visitor, exhibition, reaction_count join)
+    query = (
+        db.query(
+            VisitHistory,
+            Visitor.name.label("visitor_name"),
+            Exhibition.title.label("exhibition_title"),
+            func.count(Reaction.id).label("reaction_count")
+        )
+        .join(Visitor, VisitHistory.visitor_id == Visitor.id)
+        .join(Exhibition, VisitHistory.exhibition_id == Exhibition.id)
+        .outerjoin(Reaction, VisitHistory.id == Reaction.visit_id)
+        .group_by(VisitHistory.id, Visitor.name, Exhibition.title)
+    )
 
     if visitor_id:
         query = query.filter(VisitHistory.visitor_id == visitor_id)
     if exhibition_id:
         query = query.filter(VisitHistory.exhibition_id == exhibition_id)
 
-    visits = query.order_by(VisitHistory.id).all()
+    results = query.order_by(VisitHistory.visited_at.desc()).all()
+    
+    # VisitHistoryResponse 형식으로 변환
+    visits = []
+    for visit, visitor_name, exhibition_title, reaction_count in results:
+        visits.append({
+            "id": visit.id,
+            "visitor_id": visit.visitor_id,
+            "visitor_name": visitor_name,
+            "exhibition_id": visit.exhibition_id,
+            "exhibition_title": exhibition_title,
+            "visited_at": visit.visited_at,
+            "reaction_count": reaction_count,
+        })
+    
     return visits
 
 
 @router.get(
     "/{visit_id}",
-    response_model=VisitHistoryResponse,
+    response_model=VisitHistoryDetail,
     summary="방문 기록 상세 조회",
-    description="방문 기록 ID로 상세 정보를 조회합니다.",
+    description="방문 기록 ID로 상세 정보를 조회합니다. 전시 정보 및 반응 목록 포함.",
 )
 def get_visit_history(visit_id: int, db: Session = Depends(get_db)):
     """
-    방문 기록 상세 조회
+    방문 기록 상세 조회 (전체 정보)
 
     Args:
         visit_id: 방문 기록 ID
 
     Returns:
-        VisitHistoryResponse: 방문 기록 상세
+        VisitHistoryDetail: 방문 기록 상세 (exhibition, reactions 포함)
 
     Raises:
         404: 방문 기록을 찾을 수 없음
     """
-    visit = db.query(VisitHistory).filter(VisitHistory.id == visit_id).first()
+    # 방문 기록 조회 (관계 데이터 포함)
+    visit = (
+        db.query(VisitHistory)
+        .options(
+            joinedload(VisitHistory.visitor),
+            joinedload(VisitHistory.exhibition).joinedload(Exhibition.venue),
+            joinedload(VisitHistory.reactions).joinedload(Reaction.artwork)
+        )
+        .filter(VisitHistory.id == visit_id)
+        .first()
+    )
+    
     if not visit:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"방문 기록 ID {visit_id}를 찾을 수 없습니다",
         )
-    return visit
+    
+    # VisitHistoryDetail 형식으로 변환
+    result = {
+        "id": visit.id,
+        "visitor_id": visit.visitor_id,
+        "visitor_name": visit.visitor.name if visit.visitor else None,
+        "exhibition_id": visit.exhibition_id,
+        "exhibition": {
+            "id": visit.exhibition.id,
+            "title": visit.exhibition.title,
+            "venue_name": visit.exhibition.venue.name if visit.exhibition.venue else "",
+            "start_date": visit.exhibition.start_date,
+            "end_date": visit.exhibition.end_date,
+            "cover_image_url": visit.exhibition.cover_image_url,
+        } if visit.exhibition else None,
+        "visited_at": visit.visited_at,
+        "reactions": [
+            {
+                "id": reaction.id,
+                "artwork_id": reaction.artwork_id,
+                "artwork_title": reaction.artwork.title if reaction.artwork else "",
+                "comment": reaction.comment,
+                "created_at": reaction.created_at,
+            }
+            for reaction in visit.reactions
+        ],
+    }
+    
+    return result
+
+
+def get_visit_history_response(visit_id: int, db: Session) -> dict:
+    """
+    방문 기록 Response 형식으로 조회 (내부 헬퍼 함수)
+    
+    Args:
+        visit_id: 방문 기록 ID
+        db: 데이터베이스 세션
+        
+    Returns:
+        dict: VisitHistoryResponse 형식
+    """
+    result = (
+        db.query(
+            VisitHistory,
+            Visitor.name.label("visitor_name"),
+            Exhibition.title.label("exhibition_title"),
+            func.count(Reaction.id).label("reaction_count")
+        )
+        .join(Visitor, VisitHistory.visitor_id == Visitor.id)
+        .join(Exhibition, VisitHistory.exhibition_id == Exhibition.id)
+        .outerjoin(Reaction, VisitHistory.id == Reaction.visit_id)
+        .filter(VisitHistory.id == visit_id)
+        .group_by(VisitHistory.id, Visitor.name, Exhibition.title)
+        .first()
+    )
+    
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"방문 기록 ID {visit_id}를 찾을 수 없습니다",
+        )
+    
+    visit, visitor_name, exhibition_title, reaction_count = result
+    
+    return {
+        "id": visit.id,
+        "visitor_id": visit.visitor_id,
+        "visitor_name": visitor_name,
+        "exhibition_id": visit.exhibition_id,
+        "exhibition_title": exhibition_title,
+        "visited_at": visit.visited_at,
+        "reaction_count": reaction_count,
+    }

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,42 +4,66 @@ LastDance API Pydantic Schemas
 모든 API Request/Response 스키마 정의
 """
 
+# 1️⃣ 의존성 없는 기본 스키마들
+from app.schemas.venue import VenueCreate, VenueResponse, VenueUpdate
 from app.schemas.artist import ArtistCreate, ArtistResponse, ArtistUpdate
-from app.schemas.artwork import (
-    ArtworkCreate,
-    ArtworkDetail,
-    ArtworkResponse,
-    ArtworkUpdate,
-)
-from app.schemas.exhibition import (
-    ExhibitionCreate,
-    ExhibitionDetail,
-    ExhibitionResponse,
-    ExhibitionUpdate,
-)
-from app.schemas.reaction import (
-    ReactionCreate,
-    ReactionDetail,
-    ReactionResponse,
-    ReactionUpdate,
-)
-from app.schemas.tag import TagCreate, TagDetail, TagResponse, TagUpdate
+from app.schemas.visitor import VisitorCreate, VisitorResponse, VisitorUpdate
+
+# 2️⃣ TagCategory (TagResponse보다 먼저)
 from app.schemas.tag_category import (
+    TagCategoryBase,
     TagCategoryCreate,
     TagCategoryDetail,
     TagCategoryResponse,
     TagCategoryUpdate,
 )
-from app.schemas.venue import VenueCreate, VenueResponse, VenueUpdate
+
+# 3️⃣ Tag (TagCategoryBase 사용)
+from app.schemas.tag import TagCreate, TagDetail, TagResponse, TagUpdate
+
+# 4️⃣ Exhibition (ArtworkSummary, ExhibitionSummary 포함)
+from app.schemas.exhibition import (
+    ArtistSummary,
+    ArtworkSummary,
+    ExhibitionCreate,
+    ExhibitionDetail,
+    ExhibitionResponse,
+    ExhibitionSummary,
+    ExhibitionUpdate,
+)
+
+# 5️⃣ Artwork (ExhibitionSummary 사용)
+from app.schemas.artwork import (
+    ArtworkCreate,
+    ArtworkDetail,
+    ArtworkMatchRequest,
+    ArtworkMatchResponse,
+    ArtworkMatchResult,
+    ArtworkResponse,
+    ArtworkUpdate,
+)
+
+# 6️⃣ VisitHistory (VisitHistorySummary 포함)
 from app.schemas.visit_history import (
     VisitHistoryCreate,
     VisitHistoryDetail,
     VisitHistoryResponse,
+    VisitHistorySummary,
 )
-from app.schemas.visitor import VisitorCreate, VisitorResponse, VisitorUpdate
 
-# Forward Reference 해결 (순환 참조 방지)
+# 7️⃣ Reaction (ReactionSummary 포함)
+from app.schemas.reaction import (
+    ReactionCreate,
+    ReactionDetail,
+    ReactionResponse,
+    ReactionSummary,
+    ReactionUpdate,
+)
+
+# 8️⃣ Forward Reference 해결
+TagCategoryResponse.model_rebuild()
 TagCategoryDetail.model_rebuild()
+TagResponse.model_rebuild()
 TagDetail.model_rebuild()
 ExhibitionDetail.model_rebuild()
 ArtworkDetail.model_rebuild()
@@ -47,16 +71,6 @@ VisitHistoryDetail.model_rebuild()
 ReactionDetail.model_rebuild()
 
 __all__ = [
-    # TagCategory
-    "TagCategoryCreate",
-    "TagCategoryUpdate",
-    "TagCategoryResponse",
-    "TagCategoryDetail",
-    # Tag
-    "TagCreate",
-    "TagUpdate",
-    "TagResponse",
-    "TagDetail",
     # Venue
     "VenueCreate",
     "VenueUpdate",
@@ -69,23 +83,42 @@ __all__ = [
     "VisitorCreate",
     "VisitorUpdate",
     "VisitorResponse",
+    # TagCategory
+    "TagCategoryBase",
+    "TagCategoryCreate",
+    "TagCategoryUpdate",
+    "TagCategoryResponse",
+    "TagCategoryDetail",
+    # Tag
+    "TagCreate",
+    "TagUpdate",
+    "TagResponse",
+    "TagDetail",
     # Exhibition
     "ExhibitionCreate",
     "ExhibitionUpdate",
     "ExhibitionResponse",
     "ExhibitionDetail",
+    "ExhibitionSummary",
+    "ArtworkSummary",
+    "ArtistSummary",
     # Artwork
     "ArtworkCreate",
     "ArtworkUpdate",
     "ArtworkResponse",
     "ArtworkDetail",
+    "ArtworkMatchRequest",
+    "ArtworkMatchResult",
+    "ArtworkMatchResponse",
     # VisitHistory
     "VisitHistoryCreate",
     "VisitHistoryResponse",
     "VisitHistoryDetail",
+    "VisitHistorySummary",
     # Reaction
     "ReactionCreate",
     "ReactionUpdate",
     "ReactionResponse",
     "ReactionDetail",
+    "ReactionSummary",
 ]

--- a/app/schemas/artist.py
+++ b/app/schemas/artist.py
@@ -16,7 +16,6 @@ class ArtistCreate(BaseModel):
     Note:
         uuid는 서버에서 자동 생성
     """
-
     name: str = Field(..., description="작가명")
     bio: Optional[str] = Field(None, description="작가 소개")
     email: Optional[EmailStr] = Field(None, description="이메일")
@@ -31,7 +30,6 @@ class ArtistUpdate(BaseModel):
         bio: 작가 소개 (선택)
         email: 이메일 (선택)
     """
-
     name: Optional[str] = None
     bio: Optional[str] = None
     email: Optional[EmailStr] = None
@@ -50,7 +48,6 @@ class ArtistResponse(BaseModel):
         created_at: 생성일시
         updated_at: 수정일시
     """
-
     id: int
     uuid: str
     name: str

--- a/app/schemas/artwork.py
+++ b/app/schemas/artwork.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from app.schemas.artist import ArtistResponse
-    from app.schemas.exhibition import ExhibitionResponse
+    from app.schemas.exhibition import ExhibitionSummary
 
 
 class ArtworkCreate(BaseModel):
@@ -19,7 +19,6 @@ class ArtworkCreate(BaseModel):
         year: 제작 연도 (선택)
         thumbnail_url: 썸네일 이미지 URL (선택)
     """
-
     title: str = Field(..., description="작품 제목")
     artist_id: int = Field(..., description="작가 ID")
     description: Optional[str] = Field(None, description="작품 설명")
@@ -38,7 +37,6 @@ class ArtworkUpdate(BaseModel):
         year: 제작 연도 (선택)
         thumbnail_url: 썸네일 이미지 URL (선택)
     """
-
     title: Optional[str] = None
     artist_id: Optional[int] = None
     description: Optional[str] = None
@@ -48,25 +46,30 @@ class ArtworkUpdate(BaseModel):
 
 class ArtworkResponse(BaseModel):
     """
-    작품 기본 응답
+    작품 기본 응답 (리스트용)
+    
+    GET /artworks 리스트 조회 시 사용
 
     Attributes:
         id: 작품 ID
         title: 작품 제목
         artist_id: 작가 ID
+        artist_name: 작가 이름
         description: 작품 설명
         year: 제작 연도
         thumbnail_url: 썸네일 URL
+        reaction_count: 해당 작품의 반응 개수
         created_at: 생성일시
         updated_at: 수정일시
     """
-
     id: int
     title: str
     artist_id: int
+    artist_name: str
     description: Optional[str] = None
     year: Optional[int] = None
     thumbnail_url: Optional[str] = None
+    reaction_count: int = 0
     created_at: datetime
     updated_at: Optional[datetime] = None
 
@@ -74,52 +77,88 @@ class ArtworkResponse(BaseModel):
         from_attributes = True
 
 
-class ArtworkDetail(ArtworkResponse):
+class ArtworkDetail(BaseModel):
     """
-    작품 상세 응답 (작가, 전시 정보 포함)
+    작품 상세 응답 (상세 조회용)
+    
+    GET /artworks/{id} 상세 조회 시 사용
 
     Attributes:
-        artist: 작가 정보
-        exhibitions: 작품이 전시된 전시 목록
+        id: 작품 ID
+        title: 작품 제목
+        artist_id: 작가 ID
+        artist: 작가 전체 정보
+        description: 작품 설명
+        year: 제작 연도
+        thumbnail_url: 썸네일 URL
+        reaction_count: 해당 작품의 반응 개수
+        exhibitions: 작품이 전시된 전시 목록 (요약 정보)
+        created_at: 생성일시
+        updated_at: 수정일시
     """
-
+    id: int
+    title: str
+    artist_id: int
     artist: "ArtistResponse"
-    exhibitions: List["ExhibitionResponse"] = []
+    description: Optional[str] = None
+    year: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+    reaction_count: int = 0
+    exhibitions: List["ExhibitionSummary"] = []
+    created_at: datetime
+    updated_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True
 
 
 class ArtworkMatchRequest(BaseModel):
-    """작품 매칭 요청"""
+    """
+    작품 매칭 요청
 
+    Attributes:
+        image_base64: Base64 인코딩된 이미지
+        exhibition_id: 전시 ID
+        threshold: 유사도 임계값 (0.0 ~ 1.0)
+    """
     image_base64: str = Field(..., description="Base64 인코딩된 이미지")
     exhibition_id: int = Field(..., description="전시 ID")
     threshold: float = Field(0.7, ge=0.0, le=1.0, description="유사도 임계값")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "image_base64": "iVBORw0KGgoAAAANS...",
-                "exhibition_id": 1,
-                "threshold": 0.7,
-            }
-        }
-
 
 class ArtworkMatchResult(BaseModel):
-    """작품 매칭 결과"""
+    """
+    작품 매칭 결과
 
+    Attributes:
+        artwork_id: 작품 ID
+        title: 작품 제목
+        artist_id: 작가 ID
+        artist_name: 작가 이름
+        thumbnail_url: 썸네일 URL
+        similarity: 유사도 점수
+    """
     artwork_id: int
     title: str
     artist_id: int
+    artist_name: str
     thumbnail_url: Optional[str]
     similarity: float
 
+    class Config:
+        from_attributes = True
+
 
 class ArtworkMatchResponse(BaseModel):
-    """작품 매칭 응답"""
+    """
+    작품 매칭 응답
 
+    Attributes:
+        matched: 매칭 성공 여부
+        total_matches: 전체 매칭된 작품 수
+        threshold: 사용된 임계값
+        results: 매칭 결과 목록
+    """
     matched: bool
     total_matches: int
     threshold: float

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -1,9 +1,8 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from app.schemas.tag_category import TagCategoryResponse
+from app.schemas.tag_category import TagCategoryBase
 
 
 class TagCreate(BaseModel):
@@ -15,7 +14,6 @@ class TagCreate(BaseModel):
         category_id: 소속 카테고리 ID
         color_hex: 색상 코드 (선택, #RRGGBB 형식)
     """
-
     name: str = Field(..., description="태그명")
     category_id: int = Field(..., description="카테고리 ID")
     color_hex: Optional[str] = Field(
@@ -32,7 +30,6 @@ class TagUpdate(BaseModel):
         category_id: 카테고리 ID (선택)
         color_hex: 색상 코드 (선택)
     """
-
     name: Optional[str] = None
     category_id: Optional[int] = None
     color_hex: Optional[str] = Field(None, pattern="^#[0-9A-Fa-f]{6}$")
@@ -45,13 +42,12 @@ class TagResponse(BaseModel):
     Attributes:
         id: 태그 ID
         name: 태그명
-        category_id: 소속 카테고리 ID
+        category: 소속 카테고리 기본 정보
         color_hex: 색상 코드
     """
-
     id: int
     name: str
-    category_id: int
+    category: TagCategoryBase
     color_hex: Optional[str] = None
 
     class Config:
@@ -64,9 +60,8 @@ class TagDetail(TagResponse):
 
     Attributes:
         category: 소속 카테고리 정보
+    
+    Note: 부모 클래스에서 상속
     """
-
-    category: "TagCategoryResponse"
-
     class Config:
         from_attributes = True

--- a/app/schemas/tag_category.py
+++ b/app/schemas/tag_category.py
@@ -7,6 +7,23 @@ if TYPE_CHECKING:
     from app.schemas.tag import TagResponse
 
 
+class TagCategoryBase(BaseModel):
+    """
+    태그 카테고리 기본 정보 (순환 참조 방지용)
+    
+    Attributes:
+        id: 카테고리 ID
+        name: 카테고리명
+        color_hex: 색상 코드
+    """
+    id: int
+    name: str
+    color_hex: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
 class TagCategoryCreate(BaseModel):
     """
     태그 카테고리 생성 요청
@@ -15,7 +32,6 @@ class TagCategoryCreate(BaseModel):
         name: 카테고리명 (예: 감동이에요, 아름다워요)
         color_hex: 색상 코드 (선택, #RRGGBB 형식)
     """
-
     name: str = Field(..., description="카테고리명")
     color_hex: Optional[str] = Field(
         None, pattern="^#[0-9A-Fa-f]{6}$", description="색상 코드"
@@ -30,7 +46,6 @@ class TagCategoryUpdate(BaseModel):
         name: 카테고리명 (선택)
         color_hex: 색상 코드 (선택)
     """
-
     name: Optional[str] = None
     color_hex: Optional[str] = Field(None, pattern="^#[0-9A-Fa-f]{6}$")
 
@@ -45,13 +60,14 @@ class TagCategoryResponse(BaseModel):
         color_hex: 색상 코드
         created_at: 생성일시
         updated_at: 수정일시
+        tags: 해당 카테고리의 태그 목록
     """
-
     id: int
     name: str
     color_hex: Optional[str] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
+    tags: List["TagResponse"] = []
 
     class Config:
         from_attributes = True
@@ -63,9 +79,8 @@ class TagCategoryDetail(TagCategoryResponse):
 
     Attributes:
         tags: 해당 카테고리의 태그 목록
+    
+    Note: 부모 클래스에서 상속
     """
-
-    tags: List["TagResponse"] = []
-
     class Config:
         from_attributes = True

--- a/app/schemas/venue.py
+++ b/app/schemas/venue.py
@@ -14,7 +14,6 @@ class VenueCreate(BaseModel):
         geo_lat: 위도 (선택)
         geo_lon: 경도 (선택)
     """
-
     name: str = Field(..., description="장소명")
     address: str = Field(..., description="주소")
     geo_lat: Optional[float] = Field(None, description="위도")
@@ -31,7 +30,6 @@ class VenueUpdate(BaseModel):
         geo_lat: 위도 (선택)
         geo_lon: 경도 (선택)
     """
-
     name: Optional[str] = None
     address: Optional[str] = None
     geo_lat: Optional[float] = None
@@ -51,7 +49,6 @@ class VenueResponse(BaseModel):
         created_at: 생성일시
         updated_at: 수정일시
     """
-
     id: int
     name: str
     address: str

--- a/app/schemas/visit_history.py
+++ b/app/schemas/visit_history.py
@@ -1,12 +1,10 @@
-from datetime import datetime, date
-from typing import List
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel, Field
 
-from app.schemas.artwork import ArtworkResponse
-from app.schemas.exhibition import ExhibitionResponse
-from app.schemas.reaction import ReactionResponse
-from app.schemas.visitor import VisitorResponse
+if TYPE_CHECKING:
+    from app.schemas.exhibition import ExhibitionSummary
 
 
 class VisitHistoryCreate(BaseModel):
@@ -20,44 +18,80 @@ class VisitHistoryCreate(BaseModel):
     Note:
         visited_at은 서버에서 자동 생성 (현재 시각)
     """
-
     visitor_id: int = Field(..., description="관람객 ID")
     exhibition_id: int = Field(..., description="전시 ID")
 
 
 class VisitHistoryResponse(BaseModel):
     """
-    방문 기록 기본 응답
+    방문 기록 기본 응답 (리스트용)
+    
+    GET /visit-histories 리스트 조회 시 사용
 
     Attributes:
         id: 방문 기록 ID
         visitor_id: 관람객 ID
+        visitor_name: 관람객 이름
         exhibition_id: 전시 ID
+        exhibition_title: 전시 제목
         visited_at: 방문 일시
+        reaction_count: 해당 방문에서 작성한 반응 개수
     """
-
     id: int
     visitor_id: int
+    visitor_name: Optional[str] = None
     exhibition_id: int
+    exhibition_title: str
+    visited_at: datetime
+    reaction_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class VisitHistorySummary(BaseModel):
+    """
+    방문 기록 요약 정보 (순환 참조 방지용)
+    
+    Reaction에서 사용
+
+    Attributes:
+        id: 방문 기록 ID
+        exhibition_id: 전시 ID
+        exhibition_title: 전시 제목
+        visited_at: 방문 일시
+    """
+    id: int
+    exhibition_id: int
+    exhibition_title: str
     visited_at: datetime
 
     class Config:
         from_attributes = True
 
 
-class VisitHistoryDetail(VisitHistoryResponse):
+class VisitHistoryDetail(BaseModel):
     """
-    방문 기록 상세 응답 (관람객, 전시 정보 포함)
+    방문 기록 상세 응답 (상세 조회용)
+    
+    GET /visit-histories/{id} 상세 조회 시 사용
 
     Attributes:
-        visitor: 관람객 정보
-        exhibition: 전시 정보
-        reactions: 해당 방문에서 작성한 반응 목록
+        id: 방문 기록 ID
+        visitor_id: 관람객 ID
+        visitor_name: 관람객 이름
+        exhibition_id: 전시 ID
+        exhibition: 전시 요약 정보
+        visited_at: 방문 일시
+        reactions: 해당 방문에서 작성한 반응 목록 (요약 정보)
     """
-
-    visitor: "VisitorResponse"
-    exhibition: "ExhibitionResponse"
-    reactions: List["ReactionResponse"] = []
+    id: int
+    visitor_id: int
+    visitor_name: Optional[str] = None
+    exhibition_id: int
+    exhibition: "ExhibitionSummary"
+    visited_at: datetime
+    reactions: List["ReactionSummary"] = []
 
     class Config:
         from_attributes = True

--- a/app/schemas/visitor.py
+++ b/app/schemas/visitor.py
@@ -12,7 +12,6 @@ class VisitorCreate(BaseModel):
         uuid: iOS에서 생성한 UUID (디바이스 식별용)
         name: 관람객 이름 (선택)
     """
-
     uuid: str = Field(..., description="iOS 생성 UUID")
     name: Optional[str] = Field(None, description="관람객 이름")
 
@@ -24,7 +23,6 @@ class VisitorUpdate(BaseModel):
     Attributes:
         name: 관람객 이름
     """
-
     name: Optional[str] = None
 
 
@@ -39,7 +37,6 @@ class VisitorResponse(BaseModel):
         created_at: 생성일시
         updated_at: 수정일시
     """
-
     id: int
     uuid: str
     name: Optional[str] = None


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #65 #67 #63 #64 

---

### 🧶 주요 변경 내용 (Summary)

#### 1. 스키마 구조 개선
- **Response vs Detail 스키마 명확히 분리**
  - Response: 리스트 조회용 (가벼운 버전, 필수 정보만)
  - Detail: 상세 조회용 (전체 정보 포함)
- **순환 참조 방지를 위한 Summary 스키마 추가**
  - `ExhibitionSummary`, `ArtworkSummary`, `ReactionSummary`, `VisitHistorySummary`, `ArtistSummary`
- **중복 데이터 제거**
  - ID + 전체 객체 → ID + 이름/제목만 포함
- **필요한 집계 필드 추가**
  - `reaction_count` (작품별, 방문별)
  - `artists` (전시별 참여 작가 목록)

#### 2. 엔드포인트 성능 최적화
- **N+1 쿼리 문제 해결**
  - `joinedload`를 사용한 eager loading
  - 필요한 관계 데이터만 선택적 로드
- **집계 쿼리 최적화**
  - `func.count`로 데이터베이스 레벨 집계
- **명시적 응답 변환**
  - ORM 객체 → 딕셔너리 변환으로 응답 형식 명확화
- **생성/수정 후 상세 정보 반환**
  - 일관성 있는 API 응답

#### 3. 개선된 엔드포인트
- `reactions.py`: artwork_title, visitor_name 추가
- `artworks.py`: artist_name, reaction_count 추가
- `exhibitions.py`: venue_name, artists 목록 추가
- `visit_histories.py`: visitor_name, exhibition_title, reaction_count 추가

--- 

### 📉 개선 사항

- 데이터베이스 쿼리 개선
- 순환 참조 개선

---

### 🧪 테스트 / 검증 내역

- [x] 리스트 조회 시 가벼운 응답 확인
- [x] 상세 조회 시 전체 정보 포함 확인
- [x] N+1 쿼리 문제 해결 확인
- [x] 순환 참조 발생하지 않음 확인
- [x] API 문서(Swagger) 정상 렌더링 확인
- [x] 로컬 환경에서 전체 엔드포인트 테스트 완료

